### PR TITLE
Specify that the package uses ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 	},
 	"license": "MIT",
 	"version": "2020.05.23",
+	"type": "module",
 	"scripts": {
 		"eslint": "eslint",
 		"eslint:fix": "eslint --fix ./*.js ./src/*.js ./src/components/*.svelte ./src/graphql/*.ts ./src/routes/*.svelte ./src/routes/*.ts ./functions/*.js",


### PR DESCRIPTION
This will enforce that ES6 syntax is used and that no `require` statements sneak back in